### PR TITLE
Metric changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Make percent metrics into ratios
   * tsm_storage_pool_utilized_percent
   * tsm_volume_utilized_percent
+* Remove reason and servername label from tsm_status
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Improve events collector to not require saving any data in memory, remove --collector.events.duration-cache flag
 * Improve replicationview collector to not store any data in memory, remove --collector.replicationview.metric-cache flag
 * Remove tsm_exporter_collect_timeout metric
+* Remove tsm_libvolume_scratch metric, use sum(tsm_libvolume_media{status="scratch"}) instead
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   * tsm_storage_pool_utilized_percent
   * tsm_volume_utilized_percent
 * Remove reason and servername label from tsm_status
+* Make tsm_db_buffer_hit_ratio and tsm_db_pkg_hit_ratio a ratio between 0.0-1.0
+* Rename tsm_db_buffer_total_requests to tsm_db_buffer_requests_total
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.7.0 / TBD
+## 1.0.0-rc.0 / TBD
 
-### BREAKING CHANGES
+### **Breaking Changes**
 
 * Remove --exporter.use-cache flag and all caching logic
 * For drive metrics, replace name label with drive
@@ -10,8 +10,11 @@
 * Improve replicationview collector to not store any data in memory, remove --collector.replicationview.metric-cache flag
 * Remove tsm_exporter_collect_timeout metric
 * Remove tsm_libvolume_scratch metric, use sum(tsm_libvolume_media{status="scratch"}) instead
+* Make percent metrics into ratios
+  * tsm_storage_pool_utilized_percent
+  * tsm_volume_utilized_percent
 
-### Improvements
+### Changes
 
 * Run dsmadmc using goexpect rather than passing password at command line
 

--- a/collector/db.go
+++ b/collector/db.go
@@ -102,13 +102,13 @@ func NewDBExporter(target *config.Target, logger log.Logger) Collector {
 		FreePages: prometheus.NewDesc(prometheus.BuildFQName(namespace, "db", "pages_free"),
 			"DB free pages", []string{"dbname"}, nil),
 		BuffHitRatio: prometheus.NewDesc(prometheus.BuildFQName(namespace, "db", "buffer_hit_ratio"),
-			"DB buffer hit ratio", []string{"dbname"}, nil),
-		TotalBuffReq: prometheus.NewDesc(prometheus.BuildFQName(namespace, "db", "buffer_total_requests"),
+			"DB buffer hit ratio (0.0-1.0)", []string{"dbname"}, nil),
+		TotalBuffReq: prometheus.NewDesc(prometheus.BuildFQName(namespace, "db", "buffer_requests_total"),
 			"DB total buffer requests", []string{"dbname"}, nil),
 		SortOverflow: prometheus.NewDesc(prometheus.BuildFQName(namespace, "db", "sort_overflow"),
 			"DB sort overflow", []string{"dbname"}, nil),
 		PkgHitRatio: prometheus.NewDesc(prometheus.BuildFQName(namespace, "db", "pkg_hit_ratio"),
-			"DB pkg hit ratio", []string{"dbname"}, nil),
+			"DB pkg hit ratio (0.0-1.0)", []string{"dbname"}, nil),
 		LastBackup: prometheus.NewDesc(prometheus.BuildFQName(namespace, "db", "last_backup_time"),
 			"Time since last backup in epoch", []string{"dbname"}, nil),
 		target: target,
@@ -205,11 +205,11 @@ func dbParse(out string, logger log.Logger) []DBMetric {
 					continue
 				}
 				if strings.HasSuffix(k, "_MB") {
-					valBytes := val * 1024 * 1024
-					f.SetFloat(valBytes)
-				} else {
-					f.SetFloat(val)
+					val = val * 1024 * 1024
+				} else if strings.HasSuffix(k, "_RATIO") {
+					val = val / 100
 				}
+				f.SetFloat(val)
 			}
 		}
 		metrics = append(metrics, metric)

--- a/collector/db_test.go
+++ b/collector/db_test.go
@@ -48,12 +48,12 @@ func TestDBCollector(t *testing.T) {
 		return mockedDBStdout, nil
 	}
 	expected := `
-	# HELP tsm_db_buffer_hit_ratio DB buffer hit ratio
+	# HELP tsm_db_buffer_hit_ratio DB buffer hit ratio (0.0-1.0)
 	# TYPE tsm_db_buffer_hit_ratio gauge
-	tsm_db_buffer_hit_ratio{dbname="TSMDB1"} 88.6
-	# HELP tsm_db_buffer_total_requests DB total buffer requests
-	# TYPE tsm_db_buffer_total_requests counter
-	tsm_db_buffer_total_requests{dbname="TSMDB1"} 11607707032
+	tsm_db_buffer_hit_ratio{dbname="TSMDB1"} 0.8859999999999999
+	# HELP tsm_db_buffer_requests_total DB total buffer requests
+	# TYPE tsm_db_buffer_requests_total counter
+	tsm_db_buffer_requests_total{dbname="TSMDB1"} 11607707032
 	# HELP tsm_db_pages_free DB free pages
 	# TYPE tsm_db_pages_free gauge
 	# HELP tsm_db_last_backup_time Time since last backup in epoch
@@ -69,9 +69,9 @@ func TestDBCollector(t *testing.T) {
 	# HELP tsm_db_pages_used DB used pages
 	# TYPE tsm_db_pages_used gauge
 	tsm_db_pages_used{dbname="TSMDB1"} 25743296
-	# HELP tsm_db_pkg_hit_ratio DB pkg hit ratio
+	# HELP tsm_db_pkg_hit_ratio DB pkg hit ratio (0.0-1.0)
 	# TYPE tsm_db_pkg_hit_ratio gauge
-	tsm_db_pkg_hit_ratio{dbname="TSMDB1"} 98.3
+	tsm_db_pkg_hit_ratio{dbname="TSMDB1"} 0.983
 	# HELP tsm_db_sort_overflow DB sort overflow
 	# TYPE tsm_db_sort_overflow gauge
 	tsm_db_sort_overflow{dbname="TSMDB1"} 0
@@ -100,7 +100,7 @@ func TestDBCollector(t *testing.T) {
 	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
 		"tsm_db_space_total_bytes", "tsm_db_space_used_bytes", "tsm_db_space_free_bytes",
 		"tsm_db_pages_total", "tsm_db_pages_usable", "tsm_db_pages_used", "tsm_db_pages_free",
-		"tsm_db_buffer_hit_ratio", "tsm_db_buffer_total_requests", "tsm_db_sort_overflow", "tsm_db_pkg_hit_ratio",
+		"tsm_db_buffer_hit_ratio", "tsm_db_buffer_requests_total", "tsm_db_sort_overflow", "tsm_db_pkg_hit_ratio",
 		"tsm_db_last_backup_time",
 		"tsm_exporter_collect_error"); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)

--- a/collector/libvolumes_test.go
+++ b/collector/libvolumes_test.go
@@ -61,19 +61,16 @@ func TestLibVolumesCollector(t *testing.T) {
 	tsm_libvolume_media{mediatype="LTO-6",status="scratch"} 365
 	tsm_libvolume_media{mediatype="LTO-7",status="private"} 1082
 	tsm_libvolume_media{mediatype="LTO-7",status="scratch"} 153
-    # HELP tsm_libvolume_scratch Number of scratch tapes
-    # TYPE tsm_libvolume_scratch gauge
-    tsm_libvolume_scratch 860
 	`
 	collector := NewLibVolumesExporter(&config.Target{}, log.NewNopLogger())
 	gatherers := setupGatherer(collector)
 	if val, err := testutil.GatherAndCount(gatherers); err != nil {
 		t.Errorf("Unexpected error: %v", err)
-	} else if val != 9 {
-		t.Errorf("Unexpected collection count %d, expected 9", val)
+	} else if val != 8 {
+		t.Errorf("Unexpected collection count %d, expected 8", val)
 	}
 	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
-		"tsm_libvolume_scratch", "tsm_libvolume_media",
+		"tsm_libvolume_media",
 		"tsm_exporter_collect_error"); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}
@@ -99,7 +96,7 @@ func TestLibVolumesCollectorError(t *testing.T) {
 		t.Errorf("Unexpected collection count %d, expected 2", val)
 	}
 	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
-		"tsm_libvolume_scratch", "tsm_libvolume_media",
+		"tsm_libvolume_media",
 		"tsm_exporter_collect_error"); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}

--- a/collector/status_test.go
+++ b/collector/status_test.go
@@ -60,7 +60,7 @@ func TestStatusCollector(t *testing.T) {
 	expected := `
     # HELP tsm_status Status of TSM, 1=online 0=failure
     # TYPE tsm_status gauge
-    tsm_status{reason="",servername="SP03"} 1
+    tsm_status 1
 	`
 	collector := NewStatusExporter(&config.Target{}, log.NewNopLogger())
 	gatherers := setupGatherer(collector)
@@ -86,7 +86,7 @@ func TestStatusCollectorError(t *testing.T) {
 	expected := `
     # HELP tsm_status Status of TSM, 1=online 0=failure
     # TYPE tsm_status gauge
-    tsm_status{reason="error",servername=""} 0
+    tsm_status 0
 	`
 	collector := NewStatusExporter(&config.Target{}, log.NewNopLogger())
 	gatherers := setupGatherer(collector)

--- a/collector/stgpools.go
+++ b/collector/stgpools.go
@@ -61,7 +61,7 @@ func init() {
 func NewStoragePoolExporter(target *config.Target, logger log.Logger) Collector {
 	return &StoragePoolCollector{
 		PercentUtilized: prometheus.NewDesc(prometheus.BuildFQName(namespace, "storage_pool", "utilized_percent"),
-			"Storage pool utilized percent", []string{"storagepool", "pooltype", "classname", "storagetype"}, nil),
+			"Storage pool utilized percent (ratio of 0.0-1.0)", []string{"storagepool", "pooltype", "classname", "storagetype"}, nil),
 		target: target,
 		logger: logger,
 	}
@@ -129,11 +129,11 @@ func stgpoolsParse(out string, logger log.Logger) []StoragePoolMetric {
 					continue
 				}
 				if strings.HasSuffix(k, "_MB") {
-					valBytes := val * 1024 * 1024
-					f.SetFloat(valBytes)
-				} else {
-					f.SetFloat(val)
+					val = val * 1024 * 1024
+				} else if strings.Contains(field, "Percent") {
+					val = val / 100
 				}
+				f.SetFloat(val)
 			}
 		}
 		metrics = append(metrics, metric)

--- a/collector/stgpools_test.go
+++ b/collector/stgpools_test.go
@@ -53,11 +53,11 @@ func TestStoragePoolCollector(t *testing.T) {
 		return mockedStoragePoolStdout, nil
 	}
 	expected := `
-	# HELP tsm_storage_pool_utilized_percent Storage pool utilized percent
+	# HELP tsm_storage_pool_utilized_percent Storage pool utilized percent (ratio of 0.0-1.0)
 	# TYPE tsm_storage_pool_utilized_percent gauge
 	tsm_storage_pool_utilized_percent{classname="DISK",pooltype="PRIMARY",storagepool="ARCHIVEPOOL",storagetype="DEVCLASS"} 0.0
-	tsm_storage_pool_utilized_percent{classname="DCFILEE",pooltype="PRIMARY",storagepool="EPFESS",storagetype="DEVCLASS"} 41.8
-	tsm_storage_pool_utilized_percent{classname="DCULT7",pooltype="PRIMARY",storagepool="PTGPFS",storagetype="DEVCLASS"} 42.6
+	tsm_storage_pool_utilized_percent{classname="DCFILEE",pooltype="PRIMARY",storagepool="EPFESS",storagetype="DEVCLASS"} 0.418
+	tsm_storage_pool_utilized_percent{classname="DCULT7",pooltype="PRIMARY",storagepool="PTGPFS",storagetype="DEVCLASS"} 0.426
     # HELP tsm_exporter_collect_error Indicates if error has occurred during collection
     # TYPE tsm_exporter_collect_error gauge
     tsm_exporter_collect_error{collector="stgpools"} 0

--- a/collector/volumes.go
+++ b/collector/volumes.go
@@ -60,7 +60,7 @@ func NewVolumesExporter(target *config.Target, logger log.Logger) Collector {
 		readonly: prometheus.NewDesc(prometheus.BuildFQName(namespace, "volumes", "readonly"),
 			"Number of readonly volumes", nil, nil),
 		utilized: prometheus.NewDesc(prometheus.BuildFQName(namespace, "volume", "utilized_percent"),
-			"Volume percent utilized", []string{"volume", "classname"}, nil),
+			"Volume percent utilized (ratio of 0.0-1.0)", []string{"volume", "classname"}, nil),
 		capacity: prometheus.NewDesc(prometheus.BuildFQName(namespace, "volume", "estimated_capacity_bytes"),
 			"Volume estimated capacity", []string{"volume", "classname"}, nil),
 		target: target,
@@ -150,7 +150,7 @@ func volumesParse(out string, logger log.Logger) []VolumeMetric {
 			level.Error(logger).Log("msg", "Error parsing pct_utilized value", "value", items[2], "err", err)
 			continue
 		}
-		metric.utilized = utilized
+		metric.utilized = utilized / 100
 		metrics = append(metrics, metric)
 	}
 	return metrics

--- a/collector/volumes_test.go
+++ b/collector/volumes_test.go
@@ -61,12 +61,12 @@ func TestVolumesCollector(t *testing.T) {
 	tsm_volume_estimated_capacity_bytes{classname="DCULT7",volume="F00397L7"} 9507748970496
 	tsm_volume_estimated_capacity_bytes{classname="DCULT7",volume="F00529L7"} 6013946167296
 	tsm_volume_estimated_capacity_bytes{classname="DCULT7",volume="F00640L7"} 8597764308992
-	# HELP tsm_volume_utilized_percent Volume percent utilized
+	# HELP tsm_volume_utilized_percent Volume percent utilized (ratio of 0.0-1.0)
 	# TYPE tsm_volume_utilized_percent gauge
-	tsm_volume_utilized_percent{classname="DCULT6E",volume="E00090L6"} 100
-	tsm_volume_utilized_percent{classname="DCULT7",volume="F00397L7"} 43.7
-	tsm_volume_utilized_percent{classname="DCULT7",volume="F00529L7"} 94.6
-	tsm_volume_utilized_percent{classname="DCULT7",volume="F00640L7"} 68.5
+	tsm_volume_utilized_percent{classname="DCULT6E",volume="E00090L6"} 1.00
+	tsm_volume_utilized_percent{classname="DCULT7",volume="F00397L7"} 0.43700000000000006
+	tsm_volume_utilized_percent{classname="DCULT7",volume="F00529L7"} 0.946
+	tsm_volume_utilized_percent{classname="DCULT7",volume="F00640L7"} 0.685
     # HELP tsm_volumes_readonly Number of readonly volumes
     # TYPE tsm_volumes_readonly gauge
     tsm_volumes_readonly 1


### PR DESCRIPTION
* Remove tsm_libvolume_scratch metric, use sum(tsm_libvolume_media{status="scratch"}) instead
* Make percent metrics into ratios
  * tsm_storage_pool_utilized_percent
  * tsm_volume_utilized_percent
* Remove reason and servername label from tsm_status
* Make tsm_db_buffer_hit_ratio and tsm_db_pkg_hit_ratio a ratio between 0.0-1.0
* Rename tsm_db_buffer_total_requests to tsm_db_buffer_requests_total