### PR TITLE
Ensure timestamp metrics have proper naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 * Remove reason and servername label from tsm_status
 * Make tsm_db_buffer_hit_ratio and tsm_db_pkg_hit_ratio a ratio between 0.0-1.0
 * Rename tsm_db_buffer_total_requests to tsm_db_buffer_requests_total
+* Rename tsm_db_last_backup_time to tsm_db_last_backup_timestamp_seconds
+* Rename tsm_replication_end_time to tsm_replication_end_timestamp_seconds
+* Rename tsm_replication_start_time to tsm_replication_start_timestamp_seconds
 
 ### Changes
 

--- a/collector/db.go
+++ b/collector/db.go
@@ -109,7 +109,7 @@ func NewDBExporter(target *config.Target, logger log.Logger) Collector {
 			"DB sort overflow", []string{"dbname"}, nil),
 		PkgHitRatio: prometheus.NewDesc(prometheus.BuildFQName(namespace, "db", "pkg_hit_ratio"),
 			"DB pkg hit ratio (0.0-1.0)", []string{"dbname"}, nil),
-		LastBackup: prometheus.NewDesc(prometheus.BuildFQName(namespace, "db", "last_backup_time"),
+		LastBackup: prometheus.NewDesc(prometheus.BuildFQName(namespace, "db", "last_backup_timestamp_seconds"),
 			"Time since last backup in epoch", []string{"dbname"}, nil),
 		target: target,
 		logger: logger,

--- a/collector/db_test.go
+++ b/collector/db_test.go
@@ -56,9 +56,9 @@ func TestDBCollector(t *testing.T) {
 	tsm_db_buffer_requests_total{dbname="TSMDB1"} 11607707032
 	# HELP tsm_db_pages_free DB free pages
 	# TYPE tsm_db_pages_free gauge
-	# HELP tsm_db_last_backup_time Time since last backup in epoch
-	# TYPE tsm_db_last_backup_time gauge
-	tsm_db_last_backup_time{dbname="TSMDB1"} 1.590135e+09
+	# HELP tsm_db_last_backup_timestamp_seconds Time since last backup in epoch
+	# TYPE tsm_db_last_backup_timestamp_seconds gauge
+	tsm_db_last_backup_timestamp_seconds{dbname="TSMDB1"} 1.590135e+09
 	tsm_db_pages_free{dbname="TSMDB1"} 3092796
 	# HELP tsm_db_pages_total DB total pages
 	# TYPE tsm_db_pages_total gauge
@@ -101,7 +101,7 @@ func TestDBCollector(t *testing.T) {
 		"tsm_db_space_total_bytes", "tsm_db_space_used_bytes", "tsm_db_space_free_bytes",
 		"tsm_db_pages_total", "tsm_db_pages_usable", "tsm_db_pages_used", "tsm_db_pages_free",
 		"tsm_db_buffer_hit_ratio", "tsm_db_buffer_requests_total", "tsm_db_sort_overflow", "tsm_db_pkg_hit_ratio",
-		"tsm_db_last_backup_time",
+		"tsm_db_last_backup_timestamp_seconds",
 		"tsm_exporter_collect_error"); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}

--- a/collector/replicationview.go
+++ b/collector/replicationview.go
@@ -63,9 +63,9 @@ func NewReplicationViewsExporter(target *config.Target, logger log.Logger) Colle
 	return &ReplicationViewsCollector{
 		NotCompleted: prometheus.NewDesc(prometheus.BuildFQName(namespace, "replication", "not_completed"),
 			"Number of replications not completed for today", []string{"nodename", "fsname"}, nil),
-		StartTime: prometheus.NewDesc(prometheus.BuildFQName(namespace, "replication", "start_time"),
+		StartTime: prometheus.NewDesc(prometheus.BuildFQName(namespace, "replication", "start_timestamp_seconds"),
 			"Start time of replication", []string{"nodename", "fsname"}, nil),
-		EndTime: prometheus.NewDesc(prometheus.BuildFQName(namespace, "replication", "end_time"),
+		EndTime: prometheus.NewDesc(prometheus.BuildFQName(namespace, "replication", "end_timestamp_seconds"),
 			"End time of replication", []string{"nodename", "fsname"}, nil),
 		Duration: prometheus.NewDesc(prometheus.BuildFQName(namespace, "replication", "duration_seconds"),
 			"Amount of time taken to complete the most recent replication", []string{"nodename", "fsname"}, nil),

--- a/collector/replicationview_test.go
+++ b/collector/replicationview_test.go
@@ -106,6 +106,12 @@ func TestReplicationViewsCollector(t *testing.T) {
 	tsm_replication_duration_seconds{fsname="/TEST4",nodename="TEST2DB2"} 19276
 	tsm_replication_duration_seconds{fsname="/BAR",nodename="FOO"} 0
 	tsm_replication_duration_seconds{fsname="/BAZ",nodename="BAR"} 0
+	# HELP tsm_replication_end_timestamp_seconds End time of replication
+	# TYPE tsm_replication_end_timestamp_seconds gauge
+	tsm_replication_end_timestamp_seconds{fsname="/TEST2CONF",nodename="TEST2DB2"} 1584943605
+	tsm_replication_end_timestamp_seconds{fsname="/TEST4",nodename="TEST2DB2"} 1584943605
+	tsm_replication_end_timestamp_seconds{fsname="/BAR",nodename="FOO"} 0
+	tsm_replication_end_timestamp_seconds{fsname="/BAZ",nodename="BAR"} 0
 	# HELP tsm_replication_not_completed Number of replications not completed for today
 	# TYPE tsm_replication_not_completed gauge
 	tsm_replication_not_completed{fsname="/TEST2CONF",nodename="TEST2DB2"} 0
@@ -124,6 +130,12 @@ func TestReplicationViewsCollector(t *testing.T) {
 	tsm_replication_replicated_files{fsname="/TEST4",nodename="TEST2DB2"} 2
 	tsm_replication_replicated_files{fsname="/BAR",nodename="FOO"} 0
 	tsm_replication_replicated_files{fsname="/BAZ",nodename="BAR"} 0
+	# HELP tsm_replication_start_timestamp_seconds Start time of replication
+	# TYPE tsm_replication_start_timestamp_seconds gauge
+	tsm_replication_start_timestamp_seconds{fsname="/TEST2CONF",nodename="TEST2DB2"} 1584924329
+	tsm_replication_start_timestamp_seconds{fsname="/TEST4",nodename="TEST2DB2"} 1584924329
+	tsm_replication_start_timestamp_seconds{fsname="/BAR",nodename="FOO"} 0
+	tsm_replication_start_timestamp_seconds{fsname="/BAZ",nodename="BAR"} 0
 	`
 	collector := NewReplicationViewsExporter(&config.Target{}, log.NewNopLogger())
 	gatherers := setupGatherer(collector)
@@ -135,6 +147,7 @@ func TestReplicationViewsCollector(t *testing.T) {
 	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
 		"tsm_replication_duration_seconds", "tsm_replication_not_completed",
 		"tsm_replication_replicated_bytes", "tsm_replication_replicated_files",
+		"tsm_replication_start_timestamp_seconds", "tsm_replication_end_timestamp_seconds",
 		"tsm_exporter_collect_error"); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}


### PR DESCRIPTION
* Rename tsm_db_last_backup_time to tsm_db_last_backup_timestamp_seconds
* Rename tsm_replication_end_time to tsm_replication_end_timestamp_seconds
* Rename tsm_replication_start_time to tsm_replication_start_timestamp_seconds