### PR TITLE
Improve libvolumes collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * For volume metrics, replace name label with volume
 * Improve events collector to not require saving any data in memory, remove --collector.events.duration-cache flag
 * Improve replicationview collector to not store any data in memory, remove --collector.replicationview.metric-cache flag
-* Remove tsm_libvolume_scratch metric, use sum(tsm_libvolume_media{status="Scratch"}) instead
+* Remove tsm_libvolume_scratch metric, use sum(tsm_libvolume_media{status="scratch"}) instead
 * Make percent metrics into ratios
   * Rename tsm_storage_pool_utilized_percent to tsm_storage_pool_utilized_ratio
   * Rename tsm_volume_utilized_percent to tsm_volume_utilized_ratio
@@ -18,7 +18,6 @@
 * Rename tsm_db_last_backup_time to tsm_db_last_backup_timestamp_seconds
 * Rename tsm_replication_end_time to tsm_replication_end_timestamp_seconds
 * Rename tsm_replication_start_time to tsm_replication_start_timestamp_seconds
-* No longer change `tsm_libvolume_media` label `status` to be lower case, use raw value from TSM like `Private` and `Scratch`
 
 ### Changes
 
@@ -31,6 +30,7 @@
 * If numeric columns in queries are empty, do not produce errors or metrics for that missing column
 * Produce a metric for each possible drive state with `tsm_drive_state_info`
 * Improved logging when parse errors are encountered
+* Ensure `tsm_libvolume_media{status="private"}` and `tsm_libvolume_media{status="scratch"}` are always present for each mediatype/library combination
 
 ## 0.6.0 / 2020-11-06
 

--- a/collector/libvolumes_test.go
+++ b/collector/libvolumes_test.go
@@ -30,7 +30,6 @@ import (
 var (
 	mockLibVolumeStdout = `
 LTO-5,Private,LIB1,147
-LTO-5,Scratch,LIB1,342
 LTO-6,Private,LIB1,573
 LTO-6,Scratch,LIB1,365
 LTO-7,Private,LIB1,1082
@@ -57,8 +56,8 @@ func TestLibVolumesParse(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 		return
 	}
-	if len(metrics) != 6 {
-		t.Errorf("Expected 6 metrics, got %v", len(metrics))
+	if len(metrics) != 3 {
+		t.Errorf("Expected 3 metrics, got %v", len(metrics))
 	}
 }
 
@@ -66,6 +65,7 @@ func TestLibVolumesParseErrors(t *testing.T) {
 	tests := []string{
 		"LTO-5,Private,LIB1,foo\n",
 		"LTO-5,\"Private\"\",LIB1,147",
+		"LTO-7,Foo,LIB1,153\n",
 	}
 	for i, out := range tests {
 		_, err := libvolumesParse(out, log.NewNopLogger())
@@ -91,12 +91,12 @@ func TestLibVolumesCollector(t *testing.T) {
     tsm_exporter_collect_timeout{collector="libvolumes"} 0
 	# HELP tsm_libvolume_media Number of tapes
 	# TYPE tsm_libvolume_media gauge
-	tsm_libvolume_media{library="LIB1",mediatype="LTO-5",status="Private"} 147
-	tsm_libvolume_media{library="LIB1",mediatype="LTO-5",status="Scratch"} 342
-	tsm_libvolume_media{library="LIB1",mediatype="LTO-6",status="Private"} 573
-	tsm_libvolume_media{library="LIB1",mediatype="LTO-6",status="Scratch"} 365
-	tsm_libvolume_media{library="LIB1",mediatype="LTO-7",status="Private"} 1082
-	tsm_libvolume_media{library="LIB1",mediatype="LTO-7",status="Scratch"} 153
+	tsm_libvolume_media{library="LIB1",mediatype="LTO-5",status="private"} 147
+	tsm_libvolume_media{library="LIB1",mediatype="LTO-5",status="scratch"} 0
+	tsm_libvolume_media{library="LIB1",mediatype="LTO-6",status="private"} 573
+	tsm_libvolume_media{library="LIB1",mediatype="LTO-6",status="scratch"} 365
+	tsm_libvolume_media{library="LIB1",mediatype="LTO-7",status="private"} 1082
+	tsm_libvolume_media{library="LIB1",mediatype="LTO-7",status="scratch"} 153
 	`
 	collector := NewLibVolumesExporter(&config.Target{}, log.NewNopLogger())
 	gatherers := setupGatherer(collector)


### PR DESCRIPTION
* Revert back to lowercase status to match other metrics where using lowercase
* Ensure `tsm_libvolume_media{status="private"}` and `tsm_libvolume_media{status="scratch"}` are always present for each mediatype/library combination